### PR TITLE
Update xboxdrvstart.sh SCUMMVM

### DIFF
--- a/xboxdrvstart.sh
+++ b/xboxdrvstart.sh
@@ -49,8 +49,8 @@ basicGPI="sudo /opt/retropie/supplementary/xboxdrv/bin/xboxdrv \
 #Outrun Engine - select+start=quit.
 cannonball="--ui-buttonmap back+start=KEY_ESC"
 
-#Scummvm Standalone - select+start=quit, select+LB=Load State, select+RB=Save State.  Select send N for No.  Start sends Enter. Select+X=Keyboard "7"
-scummvm="--ui-buttonmap start=KEY_ENTER,back=KEY_N,back+start=KEY_LEFTCTRL+KEY_Q,back+lb=KEY_LEFTCTRL+KEY_0,back+rb=KEY_LEFTALT+KEY_0,back+x=KEY_7"
+#Scummvm Standalone - select+start=quit, Select send N for No.  Start sends Enter. Select+X=Keyboard "7"
+scummvm="--ui-buttonmap start=KEY_ENTER,back=KEY_N,back+start=KEY_LEFTCTRL+KEY_Q,start+back=KEY_LEFTCTRL+KEY_Q,back+x=KEY_7"
 
 #Streets of Rage remake
 sorr="--ui-buttonmap back+start=KEY_ESC"


### PR DESCRIPTION
i added back+start=KEY_LEFTCTRL+KEY_Q,start+back=KEY_LEFTCTRL+KEY_Q,
becasue it seemed exiting only worked when pressing select first and then additonally start. if you'd happen to press start first and then select it wouldn't exit.

Also i read in the scummvm documentation, that if the game does not present the scummvm menu when pressing R like in the monkey island series (all games that were initally programmed in SCUMM it seems) you should only use the save and load options given by the game. forcing to do otherwise can actually break the game.
in conclusion i removed the save/load hotkey function.